### PR TITLE
Feature/fix get event

### DIFF
--- a/app.go
+++ b/app.go
@@ -235,7 +235,7 @@ func getEvent(eventID, loginUserID int64) (*Event, error) {
 
 	// sheetIdがKEY. Reservation
 	reservations := map[int64]*Reservation{}
-	rows, err := db.Query("SELECT * FROM reservations WHERE event_id = ? AND canceled_at IS NULL GROUP BY event_id, sheet_id HAVING reserved_at = MIN(reserved_at)", event.ID)
+	rows, err := db.Query("SELECT * FROM reservations WHERE event_id = ? AND canceled_at IS NULL GROUP BY event_id, sheet_id HAVING reserved_at = MIN(reserved_at) FOR UPDATE", event.ID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```sql

MariaDB [torb]> explain SELECT  r.sheet_id, r.user_id, r.reserved_at FROM reservations r WHERE r.event_id = 16 AND r.canceled_at IS NULL;
+------+-------------+-------+------+---------------------------+---------------------------+---------+-------+-------+-------------+
| id   | select_type | table | type | possible_keys             | key                       | key_len | ref   | rows  | Extra       |
+------+-------------+-------+------+---------------------------+---------------------------+---------+-------+-------+-------------+
|    1 | SIMPLE      | r     | ref  | event_id_and_sheet_id_idx | event_id_and_sheet_id_idx | 4       | const | 25302 | Using where |
+------+-------------+-------+------+---------------------------+---------------------------+---------+-------+-------+-------------+
1 row in set (0.00 sec)
```

予約情報をゴリっと取ってきてN+1を解消。

